### PR TITLE
CL2-5942 - Changed the default callback url

### DIFF
--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -159,9 +159,7 @@ module OmniAuth
           nonce: new_nonce
         }.to_a
         # preserve existing URL params
-        if uri.query
-          params += URI.decode_www_form(String(uri.query))
-        end
+        params += URI.decode_www_form(String(uri.query)) if uri.query
         uri.query = URI.encode_www_form(params)
         uri.to_s
       end
@@ -184,6 +182,10 @@ module OmniAuth
 
       def redirect_uri
         options[:redirect_uri] || callback_url
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
       end
 
       ##


### PR DESCRIPTION
Changed `callback_url` from the [omniauth gem](https://github.com/omniauth/omniauth/blob/c95a5a0a50e012b3ba34401a19d589fcdf02afdf/lib/omniauth/strategy.rb#L443) default:

```ruby
def callback_url
  full_host + script_name + callback_path + query_string
end
```

to:

```ruby
def callback_url
  full_host + script_name + callback_path
end
```